### PR TITLE
Make a and kvisc more precise for hard-coded sea level values

### DIFF
--- a/atmos.m
+++ b/atmos.m
@@ -103,10 +103,10 @@ end
 if nargin <= 1 && ~nnz(h)
     % Quick return of sea level conditions.
     rho = 1.225;
-    a = 340.2940;
+    a = 340.29399054347107;
     temp = 288.15;
     press = 101325;
-    kvisc = 1.4607186e-05;
+    kvisc = 1.4607185943490473e-05;
     ZorH = 0;
     if isa(h,'DimVar')
         rho = rho*u.kg/(u.m^3);


### PR DESCRIPTION
The hard-coded "quick return" sea level values for a and kvisc are less precise than what would normally be returned at other altitudes close to 0.  Observe:

>> [rho,a,T,P,nu,z,sigma] = atmos(-eps); fprintf('rho=%.17g\na=%.17g\nT=%.17g\nP=%.17g\nnu=%.17g\nz=%.17g\nsigma=%.17g\n', rho, a, T, P, nu, z, sigma);
rho=1.2250000000000001
a=340.29399054347107
T=288.14999999999998
P=101325
nu=1.4607185943490473e-05
z=-2.2204460492503131e-16
sigma=1
>> [rho,a,T,P,nu,z,sigma] = atmos(0); fprintf('rho=%.17g\na=%.17g\nT=%.17g\nP=%.17g\nnu=%.17g\nz=%.17g\nsigma=%.17g\n', rho, a, T, P, nu, z, sigma);
rho=1.2250000000000001
a=340.29399999999998
T=288.14999999999998
P=101325
nu=1.4607186e-05
z=0
sigma=1
>> [rho,a,T,P,nu,z,sigma] = atmos(eps); fprintf('rho=%.17g\na=%.17g\nT=%.17g\nP=%.17g\nnu=%.17g\nz=%.17g\nsigma=%.17g\n', rho, a, T, P, nu, z, sigma);
rho=1.2250000000000001
a=340.29399054347107
T=288.14999999999998
P=101325
nu=1.4607185943490473e-05
z=2.2204460492503131e-16
sigma=1
>>

Fix a and kvisc so that there isn't a discontinuity around h=0.